### PR TITLE
Add fetch_cotacao helper with pytest tests

### DIFF
--- a/cotacao/__init__.py
+++ b/cotacao/__init__.py
@@ -1,0 +1,2 @@
+from .fetcher import fetch_cotacao
+__all__ = ["fetch_cotacao"]

--- a/cotacao/fetcher.py
+++ b/cotacao/fetcher.py
@@ -1,0 +1,31 @@
+"""Helpers for fetching currency exchange rates."""
+
+from __future__ import annotations
+
+import requests
+
+URL = "https://economia.awesomeapi.com.br/json/last/USD-BRL"
+
+
+def fetch_cotacao(url: str = URL) -> float:
+    """Fetch USD to BRL rate from *url* and return the bid price as float.
+
+    Raises RuntimeError if the request fails or the response structure is
+    unexpected.
+    """
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise RuntimeError("Failed to fetch cotação") from exc
+
+    try:
+        data = response.json()
+    except ValueError as exc:
+        raise RuntimeError("Invalid JSON received") from exc
+
+    try:
+        bid = data["USDBRL"]["bid"]
+        return float(bid)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise RuntimeError("Unexpected response format") from exc

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,0 +1,51 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pytest
+import requests
+
+from cotacao import fetch_cotacao
+
+
+class MockResponse:
+    def __init__(self, json_data=None, status_code=200):
+        self._json_data = json_data or {}
+        self.status_code = status_code
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code != 200:
+            raise requests.HTTPError(f"{self.status_code} Error")
+
+
+def test_fetch_cotacao_success(monkeypatch):
+    payload = {"USDBRL": {"bid": "5.10"}}
+
+    def mock_get(url):
+        return MockResponse(payload)
+
+    monkeypatch.setattr(requests, "get", mock_get)
+    assert fetch_cotacao() == 5.10
+
+
+def test_fetch_cotacao_http_error(monkeypatch):
+    def mock_get(url):
+        raise requests.RequestException("network error")
+
+    monkeypatch.setattr(requests, "get", mock_get)
+    with pytest.raises(RuntimeError):
+        fetch_cotacao()
+
+
+def test_fetch_cotacao_invalid_json(monkeypatch):
+    class BadResponse(MockResponse):
+        def json(self):
+            raise ValueError("invalid json")
+
+    def mock_get(url):
+        return BadResponse()
+
+    monkeypatch.setattr(requests, "get", mock_get)
+    with pytest.raises(RuntimeError):
+        fetch_cotacao()


### PR DESCRIPTION
## Summary
- implement `cotacao.fetcher.fetch_cotacao` that fetches USD/BRL rate
- expose helper in package init
- add pytest tests mocking `requests.get`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865c381a224832abeb28bb7968cd81d